### PR TITLE
fix: allow images to start with http/https

### DIFF
--- a/src/Extensions/MarkdownImageExtension.php
+++ b/src/Extensions/MarkdownImageExtension.php
@@ -28,7 +28,7 @@ class MarkdownImageExtension implements ExtensionInterface
             }
 
             // if this isn't an external image, set the prefix
-            if (! Str::startsWith($node->getUrl(), 'http')) {
+            if (! Str::startsWith($node->getUrl(), ['http://', 'https://'])) {
                 $originalUrl = $node->getUrl();
                 $node->setUrl(route('prezet.image', $originalUrl, false));
 


### PR DESCRIPTION
I've stumbled upon a small bug: when using images that start with `http` in the name, they won't be parsed by the extension because the check for the external image only includes `http` and not `http://` or `https://`.

**Example**

An image named `http-action-auth.png` will not be parsed correctly, resulting in a 404.

This change checks for full `http://` or `https://` to allow for images to have `http` as start of their name.