### PR TITLE
fix: force index migration

### DIFF
--- a/src/Actions/UpdateIndex.php
+++ b/src/Actions/UpdateIndex.php
@@ -96,6 +96,7 @@ class UpdateIndex
             '--database' => 'prezet',
             '--realpath' => true,
             '--no-interaction' => true,
+            '--force' => true,
         ]);
     }
 }


### PR DESCRIPTION
When trying to use the `prezet:index` command in a CI environment or while deploying it fails with a Integrity Constraint Violation:

`Integrity constraint violation: 19 UNIQUE constraint failed: documents.slug`

This happens if the `prezet.sqlite` file is already present in a production environment and you want to run an index update because `migrate:fresh` is cancelled when not using the `--force` flag.

Since probably wasn't intended for the command to not work in production twice I've added the `--force` flag to the `UpdateIndex` command.

---

It might be worth documenting a best practice here.
- should the `prezet.sqlite` file be checked into git?
- if not: how can be made sure that the index is up to date (even if you don't visit the index page)?
- how will the production environment be handled? Should the command be cancelled or just work?