### PR TITLE
Retain other query parameters in the paginator

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -81,7 +81,7 @@
                 @endforeach
             </ul>
             <div class="pt-12">
-                {{ $paginator->links() }}
+                {{ $paginator->appends(request()->query())->links() }}
             </div>
         </div>
     </section>


### PR DESCRIPTION
When you're in a tag view like `?tag=new-website`, the paginator links go to `?page=2` which takes you out of the tag view. This PR makes the paginator links go to `?tag=new-website&page=2`